### PR TITLE
fix(test): use natural language 'label selector' in description for release-4.19

### DIFF
--- a/internal/tools/analyze_anomalies.go
+++ b/internal/tools/analyze_anomalies.go
@@ -52,7 +52,7 @@ FILTERING OPTIONS:
 - namespace: Scope to a specific namespace
 - deployment: Analyze specific deployment (mutually exclusive with pod)
 - pod: Analyze specific pod (mutually exclusive with deployment)
-- label_selector: Filter by Kubernetes labels (e.g., 'app=flask')
+- label selector: Filter by Kubernetes labels (e.g., 'app=flask')
 
 Example questions this tool answers:
 - "Are there any anomalies in CPU usage?"

--- a/internal/tools/analyze_anomalies_test.go
+++ b/internal/tools/analyze_anomalies_test.go
@@ -19,7 +19,7 @@ func TestAnalyzeAnomaliesTool_Description(t *testing.T) {
 	assert.Contains(t, desc, "anomalies")
 	assert.Contains(t, desc, "deployment")
 	assert.Contains(t, desc, "pod")
-	assert.Contains(t, desc, "label_selector")
+	assert.Contains(t, desc, "label selector")
 }
 
 func TestAnalyzeAnomaliesTool_InputSchema(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #37 for release-4.19 branch

## Changes

Changed description from `label_selector` (underscore) to `label selector` (space) for consistency with main, release-4.18, and release-4.20 branches.

### Files Modified:
- `internal/tools/analyze_anomalies.go` - Line 55: Changed `label_selector` to `label selector`
- `internal/tools/analyze_anomalies_test.go` - Line 22: Changed test expectation from `label_selector` to `label selector`

## Testing

All `TestAnalyzeAnomaliesTool_*` tests pass locally.

## Rationale

This ensures all release branches use the same natural language format in the tool description, which is more user-friendly and consistent with how LLMs read and present the filtering options to users.